### PR TITLE
uniform VK with optimized digest

### DIFF
--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -96,7 +96,9 @@ impl_spartan_shape!(TestShapeCS);
 
 impl<G: Group> ShapeCS<G> {
   /// r1cs_shape but with extrpolates from one step of a uniform computation 
-  pub fn r1cs_shape_uniform(&self, N: usize) -> (R1CSShape<G>, CommitmentKey<G>) {
+  pub fn r1cs_shape_uniform(&self, N: usize) -> (R1CSShape<G>, R1CSShape<G>, CommitmentKey<G>) {
+    let S_single = self.r1cs_shape().0;
+
     let mut A: Vec<(usize, usize, G::Scalar)> = Vec::new();
     let mut B: Vec<(usize, usize, G::Scalar)> = Vec::new();
     let mut C: Vec<(usize, usize, G::Scalar)> = Vec::new();
@@ -138,9 +140,10 @@ impl<G: Group> ShapeCS<G> {
       res.unwrap()
     };
 
+
     let ck = R1CS::<G>::commitment_key(&S);
 
-    (S, ck) 
+    (S, S_single, ck) 
   }
 }
 

--- a/src/provider/hyrax_pc.rs
+++ b/src/provider/hyrax_pc.rs
@@ -323,6 +323,7 @@ where
   type VerifierKey = HyraxVerifierKey<G>;
   type EvaluationArgument = HyraxEvaluationArgument<G>;
 
+  #[tracing::instrument(skip_all, name = "HyraxEE::setup")]
   fn setup(
     ck: &<<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
   ) -> (Self::ProverKey, Self::VerifierKey) {


### PR DESCRIPTION
Created a uniform VK object that allows us to use a succinct (and still secure) representation of the R1CSShape in the digest. 