### PR TITLE
Dedupe/variable wise uniformity

### DIFF
--- a/src/spartan/upsnark.rs
+++ b/src/spartan/upsnark.rs
@@ -492,7 +492,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> PrecommittedSNARKTrait<G> for R1CSS
   ) -> Result<(ProverKey<G, EE>, UniformVerifierKey<G, EE>), SpartanError> {
     let mut cs: ShapeCS<G> = ShapeCS::new();
     let _ = circuit.synthesize(&mut cs);
-    let (S, S_single, ck) = cs.r1cs_shape_uniform(num_steps); // TODO(arasuarun): replace with precommitted version
+    let (S, S_single, ck) = cs.r1cs_shape_uniform_variablewise(num_steps); // TODO(arasuarun): replace with precommitted version
 
     let (pk_ee, vk_ee) = EE::setup(&ck);
 

--- a/src/traits/upsnark.rs
+++ b/src/traits/upsnark.rs
@@ -20,6 +20,7 @@ pub trait PrecommittedSNARKTrait<G: Group>:
   Sized + Send + Sync + Serialize + for<'de> Deserialize<'de> + UniformSNARKTrait<G> 
 {
   /// Setup that takes in the generators used to pre-committed the witness 
+  /// TODO(arasuarun): currently just sets up the circuit with variable-wise uniformity
   fn setup_precommitted<C: Circuit<G::Scalar>>(
     circuit: C,
     num_steps: usize,


### PR DESCRIPTION
Changes the organization of the witness vector from a "step-wise" uniformity to a "variable-wise uniformity". The former designs the witness vector to have all variables of a given step grouped. The latter groups by variables, putting together all copies of a variable from each of the steps. 