### PR TITLE
Optimized MSMs for small scalars

### DIFF
--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -5,7 +5,7 @@ use crate::{
   traits::{CompressedGroup, Group, PrimeFieldExt, TranscriptReprTrait},
 };
 use digest::{ExtendableOutput, Update};
-use ff::{FromUniformBytes, PrimeField};
+use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding};
 use num_bigint::BigInt;
 use num_traits::Num;

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -93,6 +93,14 @@ macro_rules! impl_traits {
         unimplemented!()
       }
 
+      fn msm_u64_wnaf(
+        _bases: &[Self::PreprocessedGroupElement],
+        _scalars: &[u64],
+        _max_num_bits: usize,
+      ) -> Self {
+        unimplemented!()
+      }
+
       fn preprocessed(&self) -> Self::PreprocessedGroupElement {
         self.to_affine()
       }

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -81,6 +81,18 @@ macro_rules! impl_traits {
         best_multiexp(scalars, bases)
       }
 
+      fn msm_binary(_bases: &[Self::PreprocessedGroupElement], _scalars: &[u64]) -> Self {
+        unimplemented!()
+      }
+
+      fn msm_small(
+        _bases: &[Self::PreprocessedGroupElement],
+        _scalars: &[u64],
+        _max_num_bits: usize,
+      ) -> Self {
+        unimplemented!()
+      }
+
       fn preprocessed(&self) -> Self::PreprocessedGroupElement {
         self.to_affine()
       }

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -5,7 +5,7 @@ use crate::{
   traits::{CompressedGroup, Group, PrimeFieldExt, TranscriptReprTrait},
 };
 use digest::{ExtendableOutput, Update};
-use ff::{FromUniformBytes, PrimeField};
+use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding};
 use halo2curves::msm::best_multiexp;
 use halo2curves::secp256k1::{Secp256k1, Secp256k1Affine, Secp256k1Compressed};

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -76,6 +76,13 @@ pub trait Group:
     max_num_bits: usize,
   ) -> Self;
 
+  /// An MSM implementation optimized for small-ish (max_num_bits <= 64) scalar values
+  fn msm_u64_wnaf(
+    bases: &[Self::PreprocessedGroupElement],
+    scalars: &[u64],
+    max_num_bits: usize,
+  ) -> Self;
+
   /// Compresses the group element
   fn compress(&self) -> Self::CompressedGroupElement;
 

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -66,6 +66,16 @@ pub trait Group:
     bases: &[Self::PreprocessedGroupElement],
   ) -> Self;
 
+  /// An MSM implementation optimized for boolean scalar values
+  fn msm_binary(bases: &[Self::PreprocessedGroupElement], scalars: &[u64]) -> Self;
+
+  /// An MSM implementation optimized for small (1 < max_num_bits < 64) scalar values
+  fn msm_small(
+    bases: &[Self::PreprocessedGroupElement],
+    scalars: &[u64],
+    max_num_bits: usize,
+  ) -> Self;
+
   /// Compresses the group element
   fn compress(&self) -> Self::CompressedGroupElement;
 
@@ -174,4 +184,4 @@ impl<G: Group, T: TranscriptReprTrait<G>> TranscriptReprTrait<G> for &[T] {
 
 pub mod evaluation;
 pub mod snark;
-pub mod upsnark; 
+pub mod upsnark;


### PR DESCRIPTION
Porting over some MSM optimizations from the jolt codebase
Reduces commitment time by 90% 🚀 