### PR TITLE
optimize: multiply_vec_uniform

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod bellpepper;
 mod constants;
 mod digest;
 mod r1cs;
+mod utils;
 
 // public modules
 pub mod errors;

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -281,9 +281,9 @@ impl<G: Group> R1CSShape<G> {
 
         let span = tracing::span!(tracing::Level::TRACE, "sparse_matrix_vec_product_uniform::multiply_row_vecs");
         let _enter = span.enter();
-        result.par_chunks_mut(num_steps).enumerate().for_each(|(step_index, step_output)| {
-              let row = &M[row_pointers[step_index]..row_pointers[step_index + 1]];
-              multiply_row_vec_uniform(row, step_output, num_steps);
+        result.par_chunks_mut(num_steps).enumerate().for_each(|(row_index, row_output)| {
+              let row = &M[row_pointers[row_index]..row_pointers[row_index + 1]];
+              multiply_row_vec_uniform(row, row_output, num_steps);
         });
 
         result 

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -263,49 +263,53 @@ impl<G: Group> R1CSShape<G> {
       indptr
     };
 
-    // Multiplies one constraint (row from small M) and its uniform copies with the vector z
-    let multiply_row_vec_uniform = |R: &[(usize, usize, G::Scalar)], z: &[G::Scalar], N: usize| -> Vec<G::Scalar> {
-      // returns the N rows of the output corresponding to the original row R in M
-      let mut result = vec![G::Scalar::ZERO; N];
+    // Multiplies one constraint (row from small M) and its uniform copies with the vector z into result
+    let multiply_row_vec_uniform = |R: &[(usize, usize, G::Scalar)], result: &mut [G::Scalar], num_steps: usize| {
       for &(_, col, val) in R {
         if col == self.num_vars {
-            result.par_iter_mut().for_each(|x| *x += val);
+          result.par_iter_mut().for_each(|x| *x += val);
         } else {
-            result.par_iter_mut().enumerate().for_each(|(i, x)| *x += val * z[col * N + i]);
+          result.par_iter_mut().enumerate().for_each(|(i, x)| *x += val * z[col * num_steps + i]);
         }
       }
-      result
     };
 
     // computes a product between a sparse uniform matrix represented by `M` and a vector `z`
     let sparse_matrix_vec_product_uniform =
-      |M: &Vec<(usize, usize, G::Scalar)>, num_rows: usize, z: &[G::Scalar]| -> Vec<G::Scalar> {
+      |M: &Vec<(usize, usize, G::Scalar)>, num_rows: usize| -> Vec<G::Scalar> {
         let row_pointers = get_row_pointers(M);
-        let result: Vec<G::Scalar> = (0..num_rows)
-          .into_par_iter()
-          .flat_map(|i| {
-              let row = &M[row_pointers[i]..row_pointers[i + 1]];
-              multiply_row_vec_uniform(row, z, num_steps)
-          })
-          .collect();
+
+        let mut result: Vec<G::Scalar> = vec![G::Scalar::ZERO; num_steps * num_rows];
+
+        let span = tracing::span!(tracing::Level::TRACE, "sparse_matrix_vec_product_uniform::multiply_row_vecs");
+        let _enter = span.enter();
+        result.par_chunks_mut(num_steps).enumerate().for_each(|(step_index, step_output)| {
+              let row = &M[row_pointers[step_index]..row_pointers[step_index + 1]];
+              multiply_row_vec_uniform(row, step_output, num_steps);
+        });
+
         result 
       };
 
     let (mut Az, (mut Bz, mut Cz)) = rayon::join(
-      || sparse_matrix_vec_product_uniform(&self.A, self.num_cons, z),
+      || sparse_matrix_vec_product_uniform(&self.A, self.num_cons),
       || {
         rayon::join(
-          || sparse_matrix_vec_product_uniform(&self.B, self.num_cons, z),
-          || sparse_matrix_vec_product_uniform(&self.C, self.num_cons, z),
+          || sparse_matrix_vec_product_uniform(&self.B, self.num_cons),
+          || sparse_matrix_vec_product_uniform(&self.C, self.num_cons),
         )
       },
     );
 
     // pad each Az, Bz, Cz to the next power of 2
     let m = max(Az.len(), max(Bz.len(), Cz.len())).next_power_of_two();
-    Az.extend(vec![G::Scalar::ZERO; m - Az.len()]);
-    Bz.extend(vec![G::Scalar::ZERO; m - Bz.len()]);
-    Cz.extend(vec![G::Scalar::ZERO; m - Cz.len()]);
+    rayon::join( 
+      || Az.resize(m, G::Scalar::ZERO),
+      || rayon::join(
+        || Bz.resize(m, G::Scalar::ZERO),
+        || Cz.resize(m, G::Scalar::ZERO)
+      )
+    );
 
     Ok((Az, Bz, Cz))
   }

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -1,9 +1,7 @@
 //! This module defines R1CS related types and a folding scheme for Relaxed R1CS
 #![allow(clippy::type_complexity)]
 use crate::{
-  errors::SpartanError,
-  traits::{commitment::CommitmentEngineTrait, Group, TranscriptReprTrait},
-  Commitment, CommitmentKey, CE,
+  errors::SpartanError, traits::{commitment::CommitmentEngineTrait, Group, TranscriptReprTrait}, utils::mul_0_1_optimized, Commitment, CommitmentKey, CE
 };
 use core::{cmp::max, marker::PhantomData};
 use ff::Field;
@@ -269,7 +267,7 @@ impl<G: Group> R1CSShape<G> {
         if col == self.num_vars {
           result.par_iter_mut().for_each(|x| *x += val);
         } else {
-          result.par_iter_mut().enumerate().for_each(|(i, x)| *x += val * z[col * num_steps + i]);
+          result.par_iter_mut().enumerate().for_each(|(i, x)| *x += mul_0_1_optimized(&val, &z[col * num_steps + i]));
         }
       }
     };

--- a/src/spartan/upsnark.rs
+++ b/src/spartan/upsnark.rs
@@ -297,6 +297,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
         small_M_evals
       };
 
+      let compute_span = tracing::span!(tracing::Level::TRACE, "compute_eval_table_sparse_single");
+      let guard = compute_span.enter();
       let (small_A_evals, (small_B_evals, small_C_evals)) = rayon::join(
         || compute_eval_table_sparse_single(&pk.S.A),
         || rayon::join(
@@ -304,17 +306,30 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
             || compute_eval_table_sparse_single(&pk.S.C),
         ),
       );
+      drop(guard);
 
       let small_RLC_evals = (0..small_A_evals.len()).into_par_iter().map(|i| {
         small_A_evals[i] + small_B_evals[i] * r + small_C_evals[i] * r * r
       }).collect::<Vec<G::Scalar>>();
 
       // 2. Handles all entries but the last one with the constant 1 variable
+      let compute_span = tracing::span!(tracing::Level::TRACE, "RLC_evals");
+      let guard = compute_span.enter();
       let mut RLC_evals: Vec<G::Scalar> = (0..pk.num_vars_total).into_par_iter().map(|col| {
-        eq_rx_ts[col % N_STEPS] * small_RLC_evals[col / N_STEPS]
+        let v = small_RLC_evals[col / N_STEPS];
+        if v == G::Scalar::ZERO {
+          G::Scalar::ZERO
+        } else if v == G::Scalar::ONE {
+          eq_rx_ts[col % N_STEPS]
+        } else {
+          eq_rx_ts[col % N_STEPS] * v
+        }
       }).collect();
       let next_pow_2 = 2 * pk.num_vars_total;
       RLC_evals.resize(next_pow_2, G::Scalar::ZERO);
+      drop(guard);
+      println!("num_vars {}", pk.S.num_vars);
+      println!("num_vars_total {}", pk.num_vars_total);
 
       // 3. Handles the constant 1 variable 
       let compute_eval_constant_column = |small_M: &Vec<(usize, usize, G::Scalar)>| -> G::Scalar {
@@ -328,6 +343,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
         constant_sum 
       };
 
+      let compute_span = tracing::span!(tracing::Level::TRACE, "compute_constant_column");
+      let guard = compute_span.enter();
       let (constant_term_A, (constant_term_B, constant_term_C)) = rayon::join(
         || compute_eval_constant_column(&pk.S.A),
         || rayon::join(
@@ -335,6 +352,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
             || compute_eval_constant_column(&pk.S.C),
         ),
       );
+      drop(guard);
 
       RLC_evals[pk.num_vars_total] = constant_term_A + r * constant_term_B + r * r * constant_term_C;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,15 @@
+use ff::PrimeField;
+
+/// a * b where there is a high P(a = {0, 1}) * P(b = {0, 1})
+#[inline(always)]
+pub fn mul_0_1_optimized<F: PrimeField>(a: &F, b: &F) -> F {
+    if a.is_zero().into() || b.is_zero().into() {
+        F::ZERO
+    } else if *a == F::ONE {
+        *b
+    } else if *b == F::ONE {
+        *a
+    } else {
+        *a * b
+    }
+}


### PR DESCRIPTION
Speeds up multiply_vec_uniform 50% largely by reducing allocations.