### PR TITLE
Compute the polynomial evaluation from within Hyrax opening proof

### DIFF
--- a/src/provider/hyrax_pc.rs
+++ b/src/provider/hyrax_pc.rs
@@ -333,7 +333,7 @@ where
     comm: &Commitment<G>,
     poly: &[G::Scalar],
     point: &[G::Scalar],
-    _eval: &G::Scalar,
+    eval: &mut Option<G::Scalar>,
   ) -> Result<Self::EvaluationArgument, SpartanError> {
     transcript.absorb(b"poly_com", comm);
 
@@ -361,6 +361,8 @@ where
     // compute the vector underneath L*Z
     // compute vector-matrix product between L and Z viewed as a matrix
     let LZ = poly_m.bound(&L);
+    // compute the evaluation as (L*Z)*R
+    *eval = Some(LZ.par_iter().zip(R.par_iter()).map(|(lz, r)| *lz * r).sum());
 
     Ok(HyraxEvaluationArgument { LZ })
   }

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -72,9 +72,13 @@ where
     comm: &Commitment<G>,
     poly: &[G::Scalar],
     point: &[G::Scalar],
-    eval: &G::Scalar,
+    eval: &mut Option<G::Scalar>,
   ) -> Result<Self::EvaluationArgument, SpartanError> {
-    let u = InnerProductInstance::new(comm, &EqPolynomial::new(point.to_vec()).evals(), eval);
+    let u = InnerProductInstance::new(
+      comm,
+      &EqPolynomial::new(point.to_vec()).evals(),
+      &eval.unwrap(),
+    );
     let w = InnerProductWitness::new(poly);
 
     InnerProductArgument::prove(ck, &pk.ck_s, &u, &w, transcript)

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -1482,7 +1482,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for Relaxe
       &comm_joint,
       &poly_joint.p,
       &r_z,
-      &eval_joint,
+      &mut Some(eval_joint),
     )?;
 
     Ok(RelaxedR1CSSNARK {

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -471,7 +471,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for Relaxe
                 &comm_joint,
                 &poly_joint.p,
                 &r_z,
-                &eval_joint,
+                &mut Some(eval_joint),
             )?;
 
         Ok(RelaxedR1CSSNARK {

--- a/src/spartan/upsnark.rs
+++ b/src/spartan/upsnark.rs
@@ -360,12 +360,9 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
       &mut transcript,
     )?;
 
-    let span = tracing::span!(tracing::Level::TRACE, "MultilinearPolynomial::evaluate_with");
-    let _enter = span.enter();
-    let eval_W = MultilinearPolynomial::evaluate_with(&W.W, &r_y[1..]);
-    drop(_enter);
-    drop(span);
-
+    // Hack: the evaluation is populated in `HyraxEvaluationEngine::prove`
+    // This will not work if `EE`` is not `HyraxEvaluationEngine`.
+    let mut eval_W: Option<G::Scalar> = None;
     let eval_arg = EE::prove(
       &pk.ck,
       &pk.pk_ee,
@@ -373,7 +370,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
       &u.comm_W,
       &W.W.clone(),
       &r_y[1..].to_vec(),
-      &eval_W,
+      &mut eval_W,
     )?;
 
     Ok(R1CSSNARK {
@@ -381,7 +378,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
       sc_proof_outer,
       claims_outer: (claim_Az, claim_Bz, claim_Cz),
       sc_proof_inner,
-      eval_W,
+      eval_W: eval_W.unwrap(),
       eval_arg,
     })
   }

--- a/src/traits/evaluation.rs
+++ b/src/traits/evaluation.rs
@@ -27,6 +27,10 @@ pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
   ) -> (Self::ProverKey, Self::VerifierKey);
 
   /// A method to prove the evaluation of a multilinear polynomial
+  /// Hack: `eval` is provided as a mutable option because in the case of Hyrax,
+  /// it's more efficient to first compute the opening proof, then compute the 
+  /// actual evaluation from that opening proof. So for `HyraxEvaluationEngine`, we 
+  /// pass in `&mut None`, which gets populated in the body of `prove`.
   fn prove(
     ck: &<<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
     pk: &Self::ProverKey,
@@ -34,7 +38,7 @@ pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
     comm: &<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment,
     poly: &[G::Scalar],
     point: &[G::Scalar],
-    eval: &G::Scalar,
+    eval: &mut Option<G::Scalar>,
   ) -> Result<Self::EvaluationArgument, SpartanError>;
 
   /// A method to verify the purported evaluation of a multilinear polynomials


### PR DESCRIPTION
Takes advantage of the fact that the opening proof does half of the work necessary to compute the evaluation
Note that this is a hacky solution that breaks support for other polynomial commitment schemes