### PR TITLE
Optimize/unnecessary allocations

### DIFF
--- a/src/provider/hyrax_pc.rs
+++ b/src/provider/hyrax_pc.rs
@@ -337,14 +337,9 @@ where
   ) -> Result<Self::EvaluationArgument, SpartanError> {
     transcript.absorb(b"poly_com", comm);
 
-    let span = tracing::span!(tracing::Level::INFO, "poly_m_construct");
-    let _guard = span.enter();
-    let poly_m = MultilinearPolynomial::<G::Scalar>::new(poly.to_vec());
-    drop(_guard);
-    drop(span);
-
     // assert vectors are of the right size
-    assert_eq!(poly_m.get_num_vars(), point.len());
+    assert!(poly.len().is_power_of_two());
+    assert_eq!(poly.len().ilog2(), point.len() as u32);
 
     let (left_num_vars, right_num_vars) =
       EqPolynomial::<G::Scalar>::compute_factored_lens(point.len());
@@ -360,7 +355,7 @@ where
 
     // compute the vector underneath L*Z
     // compute vector-matrix product between L and Z viewed as a matrix
-    let LZ = poly_m.bound(&L);
+    let LZ = MultilinearPolynomial::bound(poly, &L);
     // compute the evaluation as (L*Z)*R
     *eval = Some(LZ.par_iter().zip(R.par_iter()).map(|(lz, r)| *lz * r).sum());
 

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -1,7 +1,10 @@
 //! This module defines R1CS related types and a folding scheme for Relaxed R1CS
 #![allow(clippy::type_complexity)]
 use crate::{
-  errors::SpartanError, traits::{commitment::CommitmentEngineTrait, Group, TranscriptReprTrait}, utils::mul_0_1_optimized, Commitment, CommitmentKey, CE
+  errors::SpartanError,
+  traits::{commitment::CommitmentEngineTrait, Group, TranscriptReprTrait},
+  utils::mul_0_1_optimized,
+  Commitment, CommitmentKey, CE,
 };
 use core::{cmp::max, marker::PhantomData};
 use ff::Field;
@@ -146,7 +149,6 @@ impl<G: Group> R1CSShape<G> {
     // This is safe since we know that `M` is valid
     let sparse_matrix_vec_product =
       |M: &Vec<(usize, usize, G::Scalar)>, num_rows: usize, z: &[G::Scalar]| -> Vec<G::Scalar> {
-
         // Parallelism strategy below splits the (row, column, value) tuples into num_threads different chunks.
         // It is assumed that the tuples are (row, column) ordered. We exploit this fact to create a mutex over
         // each of the chunks and assume that only one of the threads will be writing to each chunk at a time
@@ -159,7 +161,8 @@ impl<G: Group> R1CSShape<G> {
         let mut chunks: Vec<std::sync::Mutex<Vec<G::Scalar>>> = Vec::with_capacity(num_threads);
         let mut remaining_rows = num_rows;
         (0..num_threads).for_each(|i| {
-          if i == num_threads - 1 { // the final chunk may be smaller
+          if i == num_threads - 1 {
+            // the final chunk may be smaller
             let inner = std::sync::Mutex::new(vec![G::Scalar::ZERO; remaining_rows]);
             chunks.push(inner);
           } else {
@@ -174,40 +177,42 @@ impl<G: Group> R1CSShape<G> {
 
         let span = tracing::span!(tracing::Level::TRACE, "all_chunks_multiplication");
         let _enter = span.enter();
-        M.par_chunks(thread_chunk_size).for_each(|sub_matrix: &[(usize, usize, G::Scalar)]| {
-          let (init_row, init_col, init_val) = sub_matrix[0];
-          let mut prev_chunk_index = get_chunk(init_row);
-          let curr_row_index = get_index(init_row);
-          let mut curr_chunk = chunks[prev_chunk_index].lock().unwrap();
+        M.par_chunks(thread_chunk_size)
+          .for_each(|sub_matrix: &[(usize, usize, G::Scalar)]| {
+            let (init_row, init_col, init_val) = sub_matrix[0];
+            let mut prev_chunk_index = get_chunk(init_row);
+            let curr_row_index = get_index(init_row);
+            let mut curr_chunk = chunks[prev_chunk_index].lock().unwrap();
 
-          curr_chunk[curr_row_index] += init_val * z[init_col];
+            curr_chunk[curr_row_index] += init_val * z[init_col];
 
-          let span_a = tracing::span!(tracing::Level::TRACE, "chunk_multiplication");
-          let _enter_b = span_a.enter();
-          for (row, col, val) in sub_matrix.iter().skip(1) {
-            let curr_chunk_index = get_chunk(*row);
-            if prev_chunk_index != curr_chunk_index { // only unlock the mutex again if required
-              drop(curr_chunk); // drop the curr_chunk before waiting for the next to avoid race condition
-              let new_chunk = chunks[curr_chunk_index].lock().unwrap();
-              curr_chunk = new_chunk;
+            let span_a = tracing::span!(tracing::Level::TRACE, "chunk_multiplication");
+            let _enter_b = span_a.enter();
+            for (row, col, val) in sub_matrix.iter().skip(1) {
+              let curr_chunk_index = get_chunk(*row);
+              if prev_chunk_index != curr_chunk_index {
+                // only unlock the mutex again if required
+                drop(curr_chunk); // drop the curr_chunk before waiting for the next to avoid race condition
+                let new_chunk = chunks[curr_chunk_index].lock().unwrap();
+                curr_chunk = new_chunk;
 
-              prev_chunk_index = curr_chunk_index;
+                prev_chunk_index = curr_chunk_index;
+              }
+
+              if z[*col].is_zero_vartime() {
+                continue;
+              }
+
+              let m = if z[*col].eq(&G::Scalar::ONE) {
+                *val
+              } else if val.eq(&G::Scalar::ONE) {
+                z[*col]
+              } else {
+                *val * z[*col]
+              };
+              curr_chunk[get_index(*row)] += m;
             }
-
-            if z[*col].is_zero_vartime() { 
-              continue; 
-            }
-
-            let m = if z[*col].eq(&G::Scalar::ONE) {
-              *val
-            } else if val.eq(&G::Scalar::ONE) {
-              z[*col]
-            } else {
-              *val * z[*col]
-            };
-            curr_chunk[get_index(*row)] += m;
-          }
-        });
+          });
         drop(_enter);
         drop(span);
 
@@ -221,7 +226,6 @@ impl<G: Group> R1CSShape<G> {
         }
         drop(_enter_a);
         drop(span_a);
-
 
         flat_chunks
       };
@@ -242,35 +246,46 @@ impl<G: Group> R1CSShape<G> {
   #[tracing::instrument(skip_all, name = "R1CSShape::multiply_vec_uniform")]
   pub fn multiply_vec_uniform(
     &self,
-    z: &[G::Scalar],
+    W: &[G::Scalar],
+    X: &[G::Scalar],
     num_steps: usize,
   ) -> Result<(Vec<G::Scalar>, Vec<G::Scalar>, Vec<G::Scalar>), SpartanError> {
-    if z.len() != (self.num_io + self.num_vars) * num_steps + 1 {
+    if W.len() + X.len() != (self.num_io + self.num_vars) * num_steps {
       return Err(SpartanError::InvalidWitnessLength);
     }
-    
+
     // Pre-processes matrix to return the indices of the start of each row
     let get_row_pointers = |M: &Vec<(usize, usize, G::Scalar)>| -> Vec<usize> {
       let mut indptr = vec![0; self.num_cons + 1];
       for &(row, _, _) in M {
-          indptr[row + 1] += 1;
+        indptr[row + 1] += 1;
       }
       for i in 0..self.num_cons {
-          indptr[i + 1] += indptr[i];
+        indptr[i + 1] += indptr[i];
       }
       indptr
     };
 
     // Multiplies one constraint (row from small M) and its uniform copies with the vector z into result
-    let multiply_row_vec_uniform = |R: &[(usize, usize, G::Scalar)], result: &mut [G::Scalar], num_steps: usize| {
-      for &(_, col, val) in R {
-        if col == self.num_vars {
-          result.par_iter_mut().for_each(|x| *x += val);
-        } else {
-          result.par_iter_mut().enumerate().for_each(|(i, x)| *x += mul_0_1_optimized(&val, &z[col * num_steps + i]));
+    let multiply_row_vec_uniform =
+      |R: &[(usize, usize, G::Scalar)], result: &mut [G::Scalar], num_steps: usize| {
+        for &(_, col, val) in R {
+          if col == self.num_vars {
+            result.par_iter_mut().for_each(|x| *x += val);
+          } else {
+            result.par_iter_mut().enumerate().for_each(|(i, x)| {
+              let z_index = col * num_steps + i;
+              if z_index < W.len() {
+                *x += mul_0_1_optimized(&val, &W[z_index]);
+              } else if z_index == W.len() {
+                *x += val;
+              } else {
+                *x += mul_0_1_optimized(&val, &X[z_index - W.len() - 1]);
+              }
+            });
+          }
         }
-      }
-    };
+      };
 
     // computes a product between a sparse uniform matrix represented by `M` and a vector `z`
     let sparse_matrix_vec_product_uniform =
@@ -279,14 +294,20 @@ impl<G: Group> R1CSShape<G> {
 
         let mut result: Vec<G::Scalar> = vec![G::Scalar::ZERO; num_steps * num_rows];
 
-        let span = tracing::span!(tracing::Level::TRACE, "sparse_matrix_vec_product_uniform::multiply_row_vecs");
+        let span = tracing::span!(
+          tracing::Level::TRACE,
+          "sparse_matrix_vec_product_uniform::multiply_row_vecs"
+        );
         let _enter = span.enter();
-        result.par_chunks_mut(num_steps).enumerate().for_each(|(row_index, row_output)| {
-              let row = &M[row_pointers[row_index]..row_pointers[row_index + 1]];
-              multiply_row_vec_uniform(row, row_output, num_steps);
-        });
+        result
+          .par_chunks_mut(num_steps)
+          .enumerate()
+          .for_each(|(row_index, row_output)| {
+            let row = &M[row_pointers[row_index]..row_pointers[row_index + 1]];
+            multiply_row_vec_uniform(row, row_output, num_steps);
+          });
 
-        result 
+        result
       };
 
     let (mut Az, (mut Bz, mut Cz)) = rayon::join(
@@ -301,12 +322,14 @@ impl<G: Group> R1CSShape<G> {
 
     // pad each Az, Bz, Cz to the next power of 2
     let m = max(Az.len(), max(Bz.len(), Cz.len())).next_power_of_two();
-    rayon::join( 
+    rayon::join(
       || Az.resize(m, G::Scalar::ZERO),
-      || rayon::join(
-        || Bz.resize(m, G::Scalar::ZERO),
-        || Cz.resize(m, G::Scalar::ZERO)
-      )
+      || {
+        rayon::join(
+          || Bz.resize(m, G::Scalar::ZERO),
+          || Cz.resize(m, G::Scalar::ZERO),
+        )
+      },
     );
 
     Ok((Az, Bz, Cz))
@@ -493,7 +516,6 @@ impl<G: Group> R1CSShape<G> {
       C: C_padded,
     }
   }
-
 
   /// Same as above but can have different length of constraints and num_variables
   pub fn pad_vars(&self) -> Self {

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -139,13 +139,12 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
 
   /// Bounds the polynomial's top variables using the given scalars.
   #[tracing::instrument(skip_all, name = "MultilinearPolynomial::bound")]
-  pub fn bound(&self, L: &[Scalar]) -> Vec<Scalar> {
+  pub fn bound(Z: &[Scalar], L: &[Scalar]) -> Vec<Scalar> {
     let (_left_num_vars, right_num_vars) =
-      EqPolynomial::<Scalar>::compute_factored_lens(self.num_vars);
+      EqPolynomial::<Scalar>::compute_factored_lens(Z.len().ilog2() as usize);
     let R_size = (2_usize).pow(right_num_vars as u32);
 
-    self
-      .Z
+    Z
       .par_chunks(R_size)
       .enumerate()
       // TODO(moodlezoup): optimize for 0/1

--- a/src/spartan/upsnark.rs
+++ b/src/spartan/upsnark.rs
@@ -3,9 +3,9 @@
 //! This version of Spartan does not use preprocessing so the verifier keeps the entire
 //! description of R1CS matrices. This is essentially optimal for the verifier when using
 //! an IPA-based polynomial commitment scheme.
-//! The difference between this file and snark.rs is that it trims out the "Relaxed" parts 
+//! The difference between this file and snark.rs is that it trims out the "Relaxed" parts
 //! and only works with (normal) R1CS, making it more efficient.
-//! This basic R1CSStruct also implements "uniform" and "precommitted" traits. 
+//! This basic R1CSStruct also implements "uniform" and "precommitted" traits.
 
 use crate::{
   bellpepper::{
@@ -15,15 +15,17 @@ use crate::{
   },
   digest::{DigestComputer, SimpleDigestible},
   errors::SpartanError,
-  r1cs::{R1CSShape, R1CSInstance},
+  r1cs::{R1CSInstance, R1CSShape},
   spartan::{
     polys::{eq::EqPolynomial, multilinear::MultilinearPolynomial, multilinear::SparsePolynomial},
     sumcheck::SumcheckProof,
     // PolyEvalInstance, PolyEvalWitness,
   },
   traits::{
-    commitment::CommitmentTrait, evaluation::EvaluationEngineTrait, snark::RelaxedR1CSSNARKTrait, 
-    upsnark::{UniformSNARKTrait, PrecommittedSNARKTrait}, 
+    commitment::CommitmentTrait,
+    evaluation::EvaluationEngineTrait,
+    snark::RelaxedR1CSSNARKTrait,
+    upsnark::{PrecommittedSNARKTrait, UniformSNARKTrait},
     Group, TranscriptEngineTrait,
   },
   Commitment, CommitmentKey, CompressedCommitment,
@@ -84,13 +86,12 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
 pub struct UniformProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
   ck: CommitmentKey<G>,
   pk_ee: EE::ProverKey,
-  S: R1CSShape<G>, // Single step shape
+  S: R1CSShape<G>,       // Single step shape
   num_cons_total: usize, // Number of constraints
   num_vars_total: usize, // Number of variables
-  num_steps: usize, // Number of steps
-  vk_digest: G::Scalar, // digest of the verifier's key
+  num_steps: usize,      // Number of steps
+  vk_digest: G::Scalar,  // digest of the verifier's key
 }
-
 
 /// A uniform version of the verifier's key
 #[derive(Serialize, Deserialize)]
@@ -98,9 +99,9 @@ pub struct UniformProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
 pub struct UniformVerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
   vk_ee: EE::VerifierKey,
   S_single: R1CSShape<G>, // A single step's shape
-  num_cons_total: usize, // Number of constraints
-  num_vars_total: usize, // Number of variables
-  num_steps: usize, // Number of steps
+  num_cons_total: usize,  // Number of constraints
+  num_vars_total: usize,  // Number of variables
+  num_steps: usize,       // Number of steps
   #[serde(skip, default = "OnceCell::new")]
   digest: OnceCell<G::Scalar>,
 }
@@ -108,7 +109,13 @@ pub struct UniformVerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
 impl<G: Group, EE: EvaluationEngineTrait<G>> SimpleDigestible for UniformVerifierKey<G, EE> {}
 
 impl<G: Group, EE: EvaluationEngineTrait<G>> UniformVerifierKey<G, EE> {
-  fn new(vk_ee: EE::VerifierKey, shape_single: R1CSShape<G>, num_steps: usize, num_cons_total: usize, num_vars_total: usize) -> Self {
+  fn new(
+    vk_ee: EE::VerifierKey,
+    shape_single: R1CSShape<G>,
+    num_steps: usize,
+    num_cons_total: usize,
+    num_vars_total: usize,
+  ) -> Self {
     UniformVerifierKey {
       vk_ee,
       S_single: shape_single,
@@ -124,7 +131,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> UniformVerifierKey<G, EE> {
     self
       .digest
       .get_or_try_init(|| {
-        let vk = VerifierKey::<G, EE>::new(self.S_single.clone(), self.vk_ee.clone()); 
+        let vk = VerifierKey::<G, EE>::new(self.S_single.clone(), self.vk_ee.clone());
         let dc = DigestComputer::<G::Scalar, _>::new(&vk);
         dc.digest()
       })
@@ -162,7 +169,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
 
     let (pk_ee, vk_ee) = EE::setup(&ck);
 
-    let vk: UniformVerifierKey<G, EE> = UniformVerifierKey::new(vk_ee, S.clone(), 1, num_cons_total, num_vars_total);
+    let vk: UniformVerifierKey<G, EE> =
+      UniformVerifierKey::new(vk_ee, S.clone(), 1, num_cons_total, num_vars_total);
 
     let pk = UniformProverKey {
       ck,
@@ -183,9 +191,9 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
     let _ = circuit.synthesize(&mut cs);
 
-    // Create a hollow shape with the right dimensions but no matrices. 
-    // This is a convenience to work with Spartan's r1cs_instance_and_witness function 
-    // and other padding functions without changing their signature. 
+    // Create a hollow shape with the right dimensions but no matrices.
+    // This is a convenience to work with Spartan's r1cs_instance_and_witness function
+    // and other padding functions without changing their signature.
     let hollow_S = R1CSShape::<G> {
       num_cons: pk.num_cons_total,
       num_vars: pk.num_vars_total,
@@ -203,34 +211,19 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
     let non_commitment_span = tracing::span!(tracing::Level::INFO, "PostCommitProve");
     let _guard = non_commitment_span.enter();
 
-
-    // form a padded version of the witness, W, for use in polynomial commitment later 
-    let clone_span = tracing::span!(tracing::Level::TRACE, "w.clone");
-    let _clone_enter = clone_span.enter();
-    let W: crate::r1cs::R1CSWitness<G> = w.clone();
-    drop(_clone_enter);
-    drop(clone_span);
-
-    // TODO(arasuarun): check if padding is ever required below 
+    // TODO(arasuarun): check if padding is ever required below
     // W.W.extend(vec![G::Scalar::ZERO; pk.num_vars_total - W.W.len()]);
     // let W = w.pad(&pk.S); // pad the witness
 
     let mut transcript = G::TE::new(b"R1CSSNARK");
 
     // sanity check that R1CSShape has certain size characteristics
-    // TODO(arasuarun): make sure this is enforced during setup 
+    // TODO(arasuarun): make sure this is enforced during setup
     // pk.S.check_regular_shape();
 
     // append the digest of vk (which includes R1CS matrices) and the RelaxedR1CSInstance to the transcript
     transcript.absorb(b"vk", &pk.vk_digest);
     transcript.absorb(b"U", &u);
-
-    // compute the full satisfying assignment by concatenating W.W, U.u, and U.X
-    let concat_span = tracing::span!(tracing::Level::TRACE, "concat");
-    let _concat_enter = concat_span.enter();
-    let mut z = [w.W, vec![1.into()], u.X].concat();
-    drop(_concat_enter);
-    drop(concat_span);
 
     let (num_rounds_x, num_rounds_y) = (
       usize::try_from(pk.num_cons_total.ilog2()).unwrap(),
@@ -243,13 +236,13 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
       .collect::<Result<Vec<G::Scalar>, SpartanError>>()?;
 
     let mut poly_tau = MultilinearPolynomial::new(EqPolynomial::new(tau).evals());
-    // poly_Az is the polynomial extended from the vector Az 
+    // poly_Az is the polynomial extended from the vector Az
     let (mut poly_Az, mut poly_Bz, mut poly_Cz) = {
-      let (poly_Az, poly_Bz, poly_Cz) = pk.S.multiply_vec_uniform(&z, pk.num_steps)?;
+      let (Az, Bz, Cz) = pk.S.multiply_vec_uniform(&w.W, &u.X, pk.num_steps)?;
       (
-        MultilinearPolynomial::new(poly_Az),
-        MultilinearPolynomial::new(poly_Bz),
-        MultilinearPolynomial::new(poly_Cz),
+        MultilinearPolynomial::new(Az),
+        MultilinearPolynomial::new(Bz),
+        MultilinearPolynomial::new(Cz),
       )
     };
 
@@ -271,13 +264,10 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
     )?;
 
     // claims from the end of sum-check
-    // claim_Az is the (scalar) value v_A = \sum_y A(r_x, y) * z(r_x) where r_x is the sumcheck randomness 
+    // claim_Az is the (scalar) value v_A = \sum_y A(r_x, y) * z(r_x) where r_x is the sumcheck randomness
     let (claim_Az, claim_Bz): (G::Scalar, G::Scalar) = (claims_outer[1], claims_outer[2]);
     let claim_Cz = claims_outer[3];
-    transcript.absorb(
-      b"claims_outer",
-      &[claim_Az, claim_Bz, claim_Cz].as_slice(),
-    );
+    transcript.absorb(b"claims_outer", &[claim_Az, claim_Bz, claim_Cz].as_slice());
 
     // inner sum-check
     let r = transcript.squeeze(b"r")?;
@@ -295,38 +285,43 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
 
       let N_STEPS = pk.num_steps;
 
-      // With uniformity, each entry of the RLC of A, B, C can be expressed using 
+      // With uniformity, each entry of the RLC of A, B, C can be expressed using
       // the RLC of the small_A, small_B, small_C matrices.
 
-      // 1. Evaluate \tilde smallM(r_x, y) for all y 
-      let compute_eval_table_sparse_single= |small_M: &Vec<(usize, usize, G::Scalar)>| -> Vec<G::Scalar> {
-        let mut small_M_evals = vec![G::Scalar::ZERO; pk.S.num_vars + 1];
-        for (row, col, val) in small_M.iter() {
-          small_M_evals[*col] += eq_rx_con[*row] * val;
-        }
-        small_M_evals
-      };
+      // 1. Evaluate \tilde smallM(r_x, y) for all y
+      let compute_eval_table_sparse_single =
+        |small_M: &Vec<(usize, usize, G::Scalar)>| -> Vec<G::Scalar> {
+          let mut small_M_evals = vec![G::Scalar::ZERO; pk.S.num_vars + 1];
+          for (row, col, val) in small_M.iter() {
+            small_M_evals[*col] += eq_rx_con[*row] * val;
+          }
+          small_M_evals
+        };
 
       let (small_A_evals, (small_B_evals, small_C_evals)) = rayon::join(
         || compute_eval_table_sparse_single(&pk.S.A),
-        || rayon::join(
+        || {
+          rayon::join(
             || compute_eval_table_sparse_single(&pk.S.B),
             || compute_eval_table_sparse_single(&pk.S.C),
-        ),
+          )
+        },
       );
 
-      let small_RLC_evals = (0..small_A_evals.len()).into_par_iter().map(|i| {
-        small_A_evals[i] + small_B_evals[i] * r + small_C_evals[i] * r * r
-      }).collect::<Vec<G::Scalar>>();
+      let small_RLC_evals = (0..small_A_evals.len())
+        .into_par_iter()
+        .map(|i| small_A_evals[i] + small_B_evals[i] * r + small_C_evals[i] * r * r)
+        .collect::<Vec<G::Scalar>>();
 
       // 2. Handles all entries but the last one with the constant 1 variable
-      let mut RLC_evals: Vec<G::Scalar> = (0..pk.num_vars_total).into_par_iter().map(|col| {
-        eq_rx_ts[col % N_STEPS] * small_RLC_evals[col / N_STEPS]
-      }).collect();
+      let mut RLC_evals: Vec<G::Scalar> = (0..pk.num_vars_total)
+        .into_par_iter()
+        .map(|col| eq_rx_ts[col % N_STEPS] * small_RLC_evals[col / N_STEPS])
+        .collect();
       let next_pow_2 = 2 * pk.num_vars_total;
       RLC_evals.resize(next_pow_2, G::Scalar::ZERO);
 
-      // 3. Handles the constant 1 variable 
+      // 3. Handles the constant 1 variable
       let compute_eval_constant_column = |small_M: &Vec<(usize, usize, G::Scalar)>| -> G::Scalar {
         let constant_sum: G::Scalar = small_M.iter()
           .filter(|(_, col, _)| *col == pk.S.num_vars)   // expecting ~1
@@ -335,33 +330,35 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
               *val * eq_rx_con[*row] * eq_sum
           }).sum();
 
-        constant_sum 
+        constant_sum
       };
 
       let (constant_term_A, (constant_term_B, constant_term_C)) = rayon::join(
         || compute_eval_constant_column(&pk.S.A),
-        || rayon::join(
+        || {
+          rayon::join(
             || compute_eval_constant_column(&pk.S.B),
             || compute_eval_constant_column(&pk.S.C),
-        ),
+          )
+        },
       );
 
-      RLC_evals[pk.num_vars_total] = constant_term_A + r * constant_term_B + r * r * constant_term_C;
+      RLC_evals[pk.num_vars_total] =
+        constant_term_A + r * constant_term_B + r * r * constant_term_C;
 
       RLC_evals
     };
     drop(_enter);
     drop(span);
 
-    
-    let resize_span = tracing::span!(tracing::Level::TRACE, "z.resize");
-    let _resize_enter = resize_span.enter();
-    let poly_z = {
-      z.resize(pk.num_vars_total * 2, G::Scalar::ZERO);
-      z
-    };
-    drop(_resize_enter);
-    drop(resize_span);
+    // compute the full satisfying assignment by concatenating W.W, U.u, and U.X
+    let z_span = tracing::span!(tracing::Level::TRACE, "bs");
+    let _z_enter = z_span.enter();
+    let w_clone = w.W.clone();
+    let mut z = [w.W, vec![1.into()], u.X].concat();
+    z.resize(pk.num_vars_total * 2, G::Scalar::ZERO);
+    drop(_z_enter);
+    drop(z_span);
 
     let comb_func = |poly_A_comp: &G::Scalar, poly_B_comp: &G::Scalar| -> G::Scalar {
       *poly_A_comp * *poly_B_comp
@@ -370,7 +367,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
       &claim_inner_joint, // r_A * v_A + r_B * v_B + r_C * v_C
       num_rounds_y,
       &mut MultilinearPolynomial::new(poly_ABC), // r_A * A(r_x, y) + r_B * B(r_x, y) + r_C * C(r_x, y) for all y
-      &mut MultilinearPolynomial::new(poly_z), // z(y) for all y
+      &mut MultilinearPolynomial::new(z), // z(y) for all y
       comb_func,
       &mut transcript,
     )?;
@@ -383,7 +380,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
       &pk.pk_ee,
       &mut transcript,
       &u.comm_W,
-      &W.W,
+      &w_clone,
       &r_y[1..],
       &mut eval_W,
     )?;
@@ -404,8 +401,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
     // construct an instance using the provided commitment to the witness and IO
     let comm_W = Commitment::<G>::decompress(&self.comm_W)?;
 
-    // This object has the shape dimensions but no matrices. 
-    // A convenience to work with Spartan's functions without changing their signature. 
+    // This object has the shape dimensions but no matrices.
+    // A convenience to work with Spartan's functions without changing their signature.
     let hollow_S = R1CSShape::<G> {
       num_cons: vk.num_cons_total,
       num_vars: vk.num_vars_total,
@@ -440,8 +437,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
     // verify claim_outer_final
     let (claim_Az, claim_Bz, claim_Cz) = self.claims_outer;
     let taus_bound_rx = EqPolynomial::new(tau).evaluate(&r_x);
-    let claim_outer_final_expected =
-      taus_bound_rx * (claim_Az * claim_Bz - claim_Cz);
+    let claim_outer_final_expected = taus_bound_rx * (claim_Az * claim_Bz - claim_Cz);
     if claim_outer_final != claim_outer_final_expected {
       return Err(SpartanError::InvalidSumcheckProof);
     }
@@ -485,26 +481,35 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
 
     // compute evaluations of R1CS matrices
     let multi_evaluate_uniform = |M_vec: &[&[(usize, usize, G::Scalar)]],
-                          r_x: &[G::Scalar],
-                          r_y: &[G::Scalar], 
-                          num_steps: usize,|
+                                  r_x: &[G::Scalar],
+                                  r_y: &[G::Scalar],
+                                  num_steps: usize|
      -> Vec<G::Scalar> {
-      let evaluate_with_table_uniform =
-        |M: &[(usize, usize, G::Scalar)], T_x: &[G::Scalar], T_y: &[G::Scalar], num_steps: usize| -> G::Scalar {
-          (0..M.len())
-            .into_par_iter()
-            .map(|i| {
-              let (row, col, val) = M[i];
-              (0..num_steps).into_par_iter().map(|j| {
+      let evaluate_with_table_uniform = |M: &[(usize, usize, G::Scalar)],
+                                         T_x: &[G::Scalar],
+                                         T_y: &[G::Scalar],
+                                         num_steps: usize|
+       -> G::Scalar {
+        (0..M.len())
+          .into_par_iter()
+          .map(|i| {
+            let (row, col, val) = M[i];
+            (0..num_steps)
+              .into_par_iter()
+              .map(|j| {
                 let row = row * num_steps + j;
-                let col = if col != vk.S_single.num_vars { col * num_steps + j } else { vk.num_vars_total }; 
+                let col = if col != vk.S_single.num_vars {
+                  col * num_steps + j
+                } else {
+                  vk.num_vars_total
+                };
                 let val = val * T_x[row] * T_y[col];
                 val
               })
               .sum::<G::Scalar>()
-            })
-            .sum()
-        };
+          })
+          .sum()
+      };
 
       let (T_x, T_y) = rayon::join(
         || EqPolynomial::new(r_x.to_vec()).evals(),
@@ -516,9 +521,13 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
         .map(|i| evaluate_with_table_uniform(M_vec[i], &T_x, &T_y, num_steps))
         .collect()
     };
-    
 
-    let evals = multi_evaluate_uniform(&[&vk.S_single.A, &vk.S_single.B, &vk.S_single.C], &r_x, &r_y, vk.num_steps);
+    let evals = multi_evaluate_uniform(
+      &[&vk.S_single.A, &vk.S_single.B, &vk.S_single.C],
+      &r_x,
+      &r_y,
+      vk.num_steps,
+    );
 
     let claim_inner_final_expected = (evals[0] + r * evals[1] + r * r * evals[2]) * eval_Z;
     if claim_inner_final != claim_inner_final_expected {
@@ -543,7 +552,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> UniformSNARKTrait<G> for R1CSSNARK<
   #[tracing::instrument(skip_all, name = "SNARK::setup_uniform")]
   fn setup_uniform<C: Circuit<G::Scalar>>(
     circuit: C,
-    num_steps: usize, 
+    num_steps: usize,
   ) -> Result<(UniformProverKey<G, EE>, UniformVerifierKey<G, EE>), SpartanError> {
     let mut cs: ShapeCS<G> = ShapeCS::new();
     let _ = circuit.synthesize(&mut cs);
@@ -551,13 +560,14 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> UniformSNARKTrait<G> for R1CSSNARK<
 
     let (pk_ee, vk_ee) = EE::setup(&ck);
 
-    let vk: UniformVerifierKey<G, EE> = UniformVerifierKey::new(vk_ee, S.clone(), num_steps, num_cons_total, num_vars_total);
+    let vk: UniformVerifierKey<G, EE> =
+      UniformVerifierKey::new(vk_ee, S.clone(), num_steps, num_cons_total, num_vars_total);
 
     let pk = UniformProverKey {
       ck,
       pk_ee,
-      S, 
-      num_steps, 
+      S,
+      num_steps,
       num_cons_total,
       num_vars_total,
       vk_digest: vk.digest(),
@@ -567,12 +577,11 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> UniformSNARKTrait<G> for R1CSSNARK<
   }
 }
 
-
 impl<G: Group, EE: EvaluationEngineTrait<G>> PrecommittedSNARKTrait<G> for R1CSSNARK<G, EE> {
   #[tracing::instrument(skip_all, name = "SNARK::setup_uniform")]
   fn setup_precommitted<C: Circuit<G::Scalar>>(
     circuit: C,
-    num_steps: usize, 
+    num_steps: usize,
   ) -> Result<(UniformProverKey<G, EE>, UniformVerifierKey<G, EE>), SpartanError> {
     let mut cs: ShapeCS<G> = ShapeCS::new();
     let _ = circuit.synthesize(&mut cs);
@@ -580,13 +589,14 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> PrecommittedSNARKTrait<G> for R1CSS
 
     let (pk_ee, vk_ee) = EE::setup(&ck);
 
-    let vk: UniformVerifierKey<G, EE> = UniformVerifierKey::new(vk_ee, S.clone(), num_steps, num_cons_total, num_vars_total);
+    let vk: UniformVerifierKey<G, EE> =
+      UniformVerifierKey::new(vk_ee, S.clone(), num_steps, num_cons_total, num_vars_total);
 
     let pk = UniformProverKey {
       ck,
       pk_ee,
       S,
-      num_steps, 
+      num_steps,
       num_cons_total,
       num_vars_total,
       vk_digest: vk.digest(),


### PR DESCRIPTION
removing `concat`s `to_vec`s and `clone`s