### PR TITLE
Optimize: add zero / one special cases

### DIFF
--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -14,7 +14,10 @@ use rayon::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::spartan::{math::Math, polys::eq::EqPolynomial};
+use crate::{
+  spartan::{math::Math, polys::eq::EqPolynomial},
+  utils::mul_0_1_optimized,
+};
 
 /// A multilinear extension of a polynomial $Z(\cdot)$, denote it as $\tilde{Z}(x_1, ..., x_m)$
 /// where the degree of each variable is at most one.
@@ -87,22 +90,20 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     self.num_vars -= 1;
   }
 
-  /// Bounds the polynomial's most significant index bit to 'r' optimized for a 
+  /// Bounds the polynomial's most significant index bit to 'r' optimized for a
   /// high P(eval = 0).
   #[tracing::instrument(skip_all)]
   pub fn bound_poly_var_top_zero_optimized(&mut self, r: &Scalar) {
     let n = self.len() / 2;
 
     let (left, right) = self.Z.split_at_mut(n);
-    let (right, _) = right.split_at(n);
 
     left
       .par_iter_mut()
       .zip(right.par_iter())
+      .filter(|(&mut a, &b)| a != b)
       .for_each(|(a, b)| {
-        if !(*a == Scalar::ZERO && *b == Scalar::ZERO) {
-          *a += *r * (*b - *a);
-        }
+        *a += *r * (*b - *a);
       });
 
     self.Z.resize(n, Scalar::ZERO);
@@ -166,11 +167,14 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
       EqPolynomial::<Scalar>::compute_factored_lens(Z.len().ilog2() as usize);
     let R_size = (2_usize).pow(right_num_vars as u32);
 
-    Z
-      .par_chunks(R_size)
+    Z.par_chunks(R_size)
       .enumerate()
-      // TODO(moodlezoup): optimize for 0/1
-      .map(|(i, row)| row.iter().map(|x| L[i] * x).collect::<Vec<Scalar>>())
+      .map(|(i, row)| {
+        row
+          .iter()
+          .map(|x| mul_0_1_optimized(&L[i], x))
+          .collect::<Vec<Scalar>>()
+      })
       .reduce(
         || vec![Scalar::ZERO; R_size],
         |mut acc: Vec<_>, row| {

--- a/src/spartan/upsnark.rs
+++ b/src/spartan/upsnark.rs
@@ -243,40 +243,21 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
       )
     };
 
-    let comb_func_outer =
-      |poly_A_comp: &G::Scalar,
-       poly_B_comp: &G::Scalar,
-       poly_C_comp: &G::Scalar,
-       poly_D_comp: &G::Scalar|
-       -> G::Scalar {         
-        if *poly_B_comp == G::Scalar::ZERO || *poly_C_comp == G::Scalar::ZERO {
-          if *poly_D_comp == G::Scalar::ZERO {
-            G::Scalar::ZERO
-          } else {
-            *poly_A_comp * ( - (*poly_D_comp))
-          }
+    let comb_func_outer = |poly_A_comp: &G::Scalar,
+                           poly_B_comp: &G::Scalar,
+                           poly_C_comp: &G::Scalar,
+                           poly_D_comp: &G::Scalar|
+     -> G::Scalar {
+      if *poly_B_comp == G::Scalar::ZERO || *poly_C_comp == G::Scalar::ZERO {
+        if *poly_D_comp == G::Scalar::ZERO {
+          G::Scalar::ZERO
         } else {
-          *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp) 
+          *poly_A_comp * (-(*poly_D_comp))
         }
-      };
-
-    // fn count_zeros_ones_in_poly<S: PrimeField>(evals: &[S]) {
-    //     let (mut zero_count, mut one_count) = (0, 0);
-    //     for &value in evals {
-    //         if value == S::ZERO {
-    //             zero_count += 1;
-    //         } else if value == S::ONE {
-    //             one_count += 1;
-    //         }
-    //     }
-    //     let percent_zeros = (zero_count as f64 / evals.len() as f64) * 100.0;
-    //     let percent_ones = (one_count as f64 / evals.len() as f64) * 100.0;
-    //     println!("Zeros: {}, Ones: {}, Percent Zeros: {:.2}%, Percent Ones: {:.2}%", zero_count, one_count, percent_zeros, percent_ones);
-    // }
-
-    // count_zeros_ones_in_poly(poly_Az.get_Z());
-    // count_zeros_ones_in_poly(poly_Bz.get_Z());
-    // count_zeros_ones_in_poly(poly_Cz.get_Z());
+      } else {
+        *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp)
+      }
+    };
 
     let (sc_proof_outer, r_x, claims_outer) = SumcheckProof::prove_cubic_with_additive_term(
       &G::Scalar::ZERO, // claim is zero
@@ -308,7 +289,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
       let (rx_con, rx_ts) = r_x.split_at(r_x.len() - NUM_STEPS_BITS as usize);
       let eq_rx_con = EqPolynomial::new(rx_con.to_vec()).evals();
       let eq_rx_ts = EqPolynomial::new(rx_ts.to_vec()).evals();
-
+      
       let N_STEPS = pk.num_steps;
 
       // With uniformity, each entry of the RLC of A, B, C can be expressed using
@@ -377,19 +358,11 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
     drop(_enter);
     drop(span);
 
-    // println!("poly_ABC");
-    // count_zeros_ones_in_poly(&poly_ABC.clone());
-    // println!("w.W");
-    // count_zeros_ones_in_poly(&w.W);
-    // println!("u.X");
-    // count_zeros_ones_in_poly(&u.X);
-
-
     let comb_func = |poly_A_comp: &G::Scalar, poly_B_comp: &G::Scalar| -> G::Scalar {
       if *poly_A_comp == G::Scalar::ZERO || *poly_B_comp == G::Scalar::ZERO {
-          G::Scalar::ZERO
+        G::Scalar::ZERO
       } else {
-          *poly_A_comp * *poly_B_comp
+        *poly_A_comp * *poly_B_comp
       }
     };
     let (sc_proof_inner, r_y, _claims_inner) = SumcheckProof::prove_quad_unrolled(

--- a/src/spartan/upsnark.rs
+++ b/src/spartan/upsnark.rs
@@ -248,7 +248,36 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
        poly_B_comp: &G::Scalar,
        poly_C_comp: &G::Scalar,
        poly_D_comp: &G::Scalar|
-       -> G::Scalar { *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp) };
+       -> G::Scalar {         
+        if *poly_B_comp == G::Scalar::ZERO || *poly_C_comp == G::Scalar::ZERO {
+          if *poly_D_comp == G::Scalar::ZERO {
+            G::Scalar::ZERO
+          } else {
+            *poly_A_comp * ( - (*poly_D_comp))
+          }
+        } else {
+          *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp) 
+        }
+      };
+
+    // fn count_zeros_ones_in_poly<S: PrimeField>(evals: &[S]) {
+    //     let (mut zero_count, mut one_count) = (0, 0);
+    //     for &value in evals {
+    //         if value == S::ZERO {
+    //             zero_count += 1;
+    //         } else if value == S::ONE {
+    //             one_count += 1;
+    //         }
+    //     }
+    //     let percent_zeros = (zero_count as f64 / evals.len() as f64) * 100.0;
+    //     let percent_ones = (one_count as f64 / evals.len() as f64) * 100.0;
+    //     println!("Zeros: {}, Ones: {}, Percent Zeros: {:.2}%, Percent Ones: {:.2}%", zero_count, one_count, percent_zeros, percent_ones);
+    // }
+
+    // count_zeros_ones_in_poly(poly_Az.get_Z());
+    // count_zeros_ones_in_poly(poly_Bz.get_Z());
+    // count_zeros_ones_in_poly(poly_Cz.get_Z());
+
     let (sc_proof_outer, r_x, claims_outer) = SumcheckProof::prove_cubic_with_additive_term(
       &G::Scalar::ZERO, // claim is zero
       num_rounds_x,
@@ -348,8 +377,20 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for R1CSSN
     drop(_enter);
     drop(span);
 
+    // println!("poly_ABC");
+    // count_zeros_ones_in_poly(&poly_ABC.clone());
+    // println!("w.W");
+    // count_zeros_ones_in_poly(&w.W);
+    // println!("u.X");
+    // count_zeros_ones_in_poly(&u.X);
+
+
     let comb_func = |poly_A_comp: &G::Scalar, poly_B_comp: &G::Scalar| -> G::Scalar {
-      *poly_A_comp * *poly_B_comp
+      if *poly_A_comp == G::Scalar::ZERO || *poly_B_comp == G::Scalar::ZERO {
+          G::Scalar::ZERO
+      } else {
+          *poly_A_comp * *poly_B_comp
+      }
     };
     let (sc_proof_inner, r_y, _claims_inner) = SumcheckProof::prove_quad_unrolled(
       &claim_inner_joint, // r_A * v_A + r_B * v_B + r_C * v_C


### PR DESCRIPTION
40-50% reduction in sumcheck times.

I'd prefer to solve this by fixing padding and implementing algorithmic sparsity – this strategy is quite wasteful on RAM.