### PR TITLE
Remove circom

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 mod bellpepper;
 mod constants;
 mod digest;
-mod r1cs;
+pub mod r1cs;
 mod utils;
 
 // public modules
@@ -25,6 +25,8 @@ pub mod spartan;
 pub mod traits;
 
 use bellpepper_core::Circuit;
+use r1cs::R1CSShape;
+use spartan::upsnark::R1CSSNARK;
 use core::marker::PhantomData;
 use errors::SpartanError;
 use serde::{Deserialize, Serialize};
@@ -88,8 +90,8 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G> + UniformSNARKTrait<G> + Precommitted
   }
 
   /// Produces prover and verifier keys for the direct SNARK
-  pub fn setup_precommitted(circuit: C, n: usize, ck: CommitmentKey::<G>) -> Result<(ProverKey<G, S>, VerifierKey<G, S>), SpartanError> {
-    let (pk, vk) = S::setup_precommitted(circuit, n, ck)?;
+  pub fn setup_precommitted(shape: R1CSShape<G>, n: usize, ck: CommitmentKey::<G>) -> Result<(ProverKey<G, S>, VerifierKey<G, S>), SpartanError> {
+    let (pk, vk) = S::setup_precommitted(shape, n, ck)?;
     Ok((ProverKey { pk }, VerifierKey { vk }))
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,9 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G> + UniformSNARKTrait<G> + Precommitted
   }
 
   /// Produces a proof of satisfiability of the provided circuit
-  pub fn prove_precommitted(pk: &ProverKey<G, S>, circuit: C, w_segments: Vec<Vec<G::Scalar>>, comm_w_vec: Vec<Commitment<G>> ) -> Result<Self, SpartanError> {
+  pub fn prove_precommitted(pk: &ProverKey<G, S>, w_segments: Vec<Vec<G::Scalar>>, comm_w_vec: Vec<Commitment<G>> ) -> Result<Self, SpartanError> {
     // prove the instance using Spartan
-    let snark = S::prove_precommitted(&pk.pk, circuit, w_segments, comm_w_vec)?;
+    let snark = S::prove_precommitted(&pk.pk, w_segments, comm_w_vec)?;
 
     Ok(SNARK {
       snark,

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -22,12 +22,18 @@ pub struct R1CS<G: Group> {
 /// A type that holds the shape of the R1CS matrices
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct R1CSShape<G: Group> {
-  pub(crate) num_cons: usize,
-  pub(crate) num_vars: usize,
-  pub(crate) num_io: usize,
-  pub(crate) A: Vec<(usize, usize, G::Scalar)>,
-  pub(crate) B: Vec<(usize, usize, G::Scalar)>,
-  pub(crate) C: Vec<(usize, usize, G::Scalar)>,
+  /// -
+  pub num_cons: usize,
+  /// -
+  pub num_vars: usize,
+  /// -
+  pub num_io: usize,
+  /// -
+  pub A: Vec<(usize, usize, G::Scalar)>,
+  /// -
+  pub B: Vec<(usize, usize, G::Scalar)>,
+  /// -
+  pub C: Vec<(usize, usize, G::Scalar)>,
 }
 
 /// A type that holds a witness for a given R1CS instance
@@ -135,6 +141,7 @@ impl<G: Group> R1CSShape<G> {
     assert!(self.num_io < self.num_vars);
   }
 
+  /// - 
   #[tracing::instrument(skip_all, name = "R1CSShape::multiply_vec")]
   pub fn multiply_vec(
     &self,
@@ -243,6 +250,7 @@ impl<G: Group> R1CSShape<G> {
     Ok((Az, Bz, Cz))
   }
 
+  /// -
   #[tracing::instrument(skip_all, name = "R1CSShape::multiply_vec_uniform")]
   pub fn multiply_vec_uniform(
     &self,
@@ -263,6 +271,7 @@ impl<G: Group> R1CSShape<G> {
       } else if index == W.len() {
         G::Scalar::ONE
       } else {
+        println!("W.len() = {}, index = {}", W.len(), index);
         X[index - W.len() - 1]
       }
     };

--- a/src/spartan/upsnark.rs
+++ b/src/spartan/upsnark.rs
@@ -621,15 +621,11 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> PrecommittedSNARKTrait<G> for R1CSS
 
     /// produces a succinct proof of satisfiability of a `RelaxedR1CS` instance
     #[tracing::instrument(skip_all, name = "Spartan2::UPSnark::prove")]
-    fn prove_precommitted<C: Circuit<G::Scalar>>(
+    fn prove_precommitted(
       pk: &Self::ProverKey, 
-      circuit: C, 
       w_segments: Vec<Vec<G::Scalar>>,
       comm_w_vec: Vec<Commitment<G>>,
     ) -> Result<Self, SpartanError> {
-      // let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
-      // let _ = circuit.synthesize(&mut cs);
-  
       // Create a hollow shape with the right dimensions but no matrices. 
       // This is a convenience to work with Spartan's r1cs_instance_and_witness function 
       // and other padding functions without changing their signature. 

--- a/src/traits/upsnark.rs
+++ b/src/traits/upsnark.rs
@@ -29,9 +29,8 @@ pub trait PrecommittedSNARKTrait<G: Group>:
   ) -> Result<(Self::ProverKey, Self::VerifierKey), SpartanError>;
 
   /// Produces a new SNARK for a relaxed R1CS
-  fn prove_precommitted<C: Circuit<G::Scalar>>(
+  fn prove_precommitted(
     pk: &Self::ProverKey, 
-    circuit: C, 
     w_segments: Vec<Vec<G::Scalar>>,
     comm_w: Vec<Commitment<G>>, 
   ) -> Result<Self, SpartanError>;

--- a/src/traits/upsnark.rs
+++ b/src/traits/upsnark.rs
@@ -1,4 +1,5 @@
 //! This module defines a collection of traits that define the behavior of a zkSNARK for RelaxedR1CS
+use crate::r1cs::{R1CSShape, R1CS};
 use crate::{errors::SpartanError, traits::Group}; //, CommitmentKey, Commitment};
 use bellpepper_core::Circuit;
 use serde::{Deserialize, Serialize};
@@ -22,8 +23,8 @@ pub trait PrecommittedSNARKTrait<G: Group>:
   Sized + Send + Sync + Serialize + for<'de> Deserialize<'de> + UniformSNARKTrait<G> 
 {
   /// Setup that takes in the generators used to pre-committed the witness 
-  fn setup_precommitted<C: Circuit<G::Scalar>>(
-    circuit: C,
+  fn setup_precommitted(
+    shape_single: R1CSShape<G>, 
     num_steps: usize,
     ck: CommitmentKey<G>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), SpartanError>;


### PR DESCRIPTION
Spartan changes to adapt to Jolt removing circom. The main change is that the shape is provided in setup_precommitted.